### PR TITLE
Ajuste no contexto para inciar uma nova activity

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNNativeVideoPlayerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNNativeVideoPlayerModule.java
@@ -24,9 +24,11 @@ public class RNNativeVideoPlayerModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void openPlayer(@NonNull String url) {
-    ReactApplicationContext context = getReactApplicationContext();
-    Intent intent = new Intent(context, VideoPlayerActivity.class);
-    intent.putExtra("videoUrl", url);
-    context.startActivity(intent);
+    Activity activity = getCurrentActivity();
+    if (activity != null) {
+      Intent intent = new Intent(activity, VideoPlayerActivity.class);
+      intent.putExtra("videoUrl", url);
+      activity.startActivity(intent);
+    }
   }
 }


### PR DESCRIPTION
Celulares Samsung estavam crashando ao iniciar uma activity, alterei a forma como context é passado para o intent. No celular que testei parou de crashar.